### PR TITLE
Remove inconsistencies in CSV export format

### DIFF
--- a/app/Export/CsvHistoryExporter.php
+++ b/app/Export/CsvHistoryExporter.php
@@ -11,10 +11,10 @@ final class CsvHistoryExporter implements HistoryExporter
     {
         return $history->periods
             ->map(function (Period $period) {
-                $row = [sprintf('PERIOD %s: (%s)', $period->name, $period->type)];
+                $row = [sprintf('PERIOD (%s): %s', $period->type, $period->name)];
 
                 foreach ($period->events as $event) {
-                    $row[] = sprintf('EVENT %s: (%s)', $event->type, $event->name);
+                    $row[] = sprintf('EVENT (%s): %s', $event->type, $event->name);
 
                     foreach ($event->scenes as $scene) {
                         $row[] = sprintf('SCENE (%s): %s ** %s ** %s', $scene->type, $scene->question, $scene->scene, $scene->answer);


### PR DESCRIPTION
I discovered Utgar's Chronicles earlier this year and have been really enjoying it - thanks for creating this!  I just tried out the CSV export tool and noticed a couple of things that bugged me - this change makes the placement of brackets and light/dark tags consistent between Periods, Events, and Scenes in the CSV export format.